### PR TITLE
Add kubernetes support and do only latest tags builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,48 +10,36 @@ matrix:
 
   - services: docker
     env:
-    - SPARK_VERSION=2.4.2
+    - SPARK_VERSION=2.4.3
     - HADOOP_VERSION=3.1.0
+    - WITH_KUBERNETES=true
     - WITH_HIVE=true
     - WITH_PYSPARK=true
     - DIST=debian
 
   - services: docker
     env:
-    - SPARK_VERSION=2.4.2
+    - SPARK_VERSION=2.4.3
     - HADOOP_VERSION=2.7.3
+    - WITH_KUBERNETES=true
     - WITH_HIVE=true
     - WITH_PYSPARK=true
     - DIST=debian
 
   - services: docker
     env:
-    - SPARK_VERSION=2.4.1
+    - SPARK_VERSION=2.4.3
     - HADOOP_VERSION=3.1.0
+    - WITH_KUBERNETES=false
     - WITH_HIVE=true
     - WITH_PYSPARK=true
     - DIST=debian
 
   - services: docker
     env:
-    - SPARK_VERSION=2.4.1
+    - SPARK_VERSION=2.4.3
     - HADOOP_VERSION=2.7.3
-    - WITH_HIVE=true
-    - WITH_PYSPARK=true
-    - DIST=debian
-
-  - services: docker
-    env:
-    - SPARK_VERSION=2.4.0
-    - HADOOP_VERSION=3.1.0
-    - WITH_HIVE=true
-    - WITH_PYSPARK=true
-    - DIST=debian
-
-  - services: docker
-    env:
-    - SPARK_VERSION=2.4.0
-    - HADOOP_VERSION=2.7.3
+    - WITH_KUBERNETES=false
     - WITH_HIVE=true
     - WITH_PYSPARK=true
     - DIST=debian
@@ -60,30 +48,16 @@ matrix:
     env:
     - SPARK_VERSION=2.3.3
     - HADOOP_VERSION=2.7.3
+    - WITH_KUBERNETES=true
     - WITH_HIVE=true
     - WITH_PYSPARK=true
     - DIST=debian
 
   - services: docker
     env:
-    - SPARK_VERSION=2.3.2
+    - SPARK_VERSION=2.3.3
     - HADOOP_VERSION=2.7.3
-    - WITH_HIVE=true
-    - WITH_PYSPARK=true
-    - DIST=debian
-
-  - services: docker
-    env:
-    - SPARK_VERSION=2.3.1
-    - HADOOP_VERSION=2.7.3
-    - WITH_HIVE=true
-    - WITH_PYSPARK=true
-    - DIST=debian
-
-  - services: docker
-    env:
-    - SPARK_VERSION=2.3.0
-    - HADOOP_VERSION=2.7.3
+    - WITH_KUBERNETES=false
     - WITH_HIVE=true
     - WITH_PYSPARK=true
     - DIST=debian
@@ -92,30 +66,7 @@ matrix:
     env:
     - SPARK_VERSION=2.2.3
     - HADOOP_VERSION=2.7.3
-    - WITH_HIVE=true
-    - WITH_PYSPARK=true
-    - DIST=debian
-
-  - services: docker
-    env:
-    - SPARK_VERSION=2.2.2
-    - HADOOP_VERSION=2.7.3
-    - WITH_HIVE=true
-    - WITH_PYSPARK=true
-    - DIST=debian
-
-  - services: docker
-    env:
-    - SPARK_VERSION=2.2.1
-    - HADOOP_VERSION=2.7.3
-    - WITH_HIVE=true
-    - WITH_PYSPARK=true
-    - DIST=debian
-
-  - services: docker
-    env:
-    - SPARK_VERSION=2.2.0
-    - HADOOP_VERSION=2.7.3
+    - WITH_KUBERNETES=false
     - WITH_HIVE=true
     - WITH_PYSPARK=true
     - DIST=debian
@@ -124,104 +75,45 @@ matrix:
     env:
     - SPARK_VERSION=2.1.3
     - HADOOP_VERSION=2.7.3
+    - WITH_KUBERNETES=false
     - WITH_HIVE=true
     - WITH_PYSPARK=true
-    - DIST=debian
-
-  - services: docker
-    env:
-    - SPARK_VERSION=2.1.2
-    - HADOOP_VERSION=2.7.3
-    - WITH_HIVE=true
-    - WITH_PYSPARK=true
-    - DIST=debian
-
-  - services: docker
-    env:
-    - SPARK_VERSION=2.1.1
-    - HADOOP_VERSION=2.7.3
-    - WITH_HIVE=true
-    - WITH_PYSPARK=true
-    - DIST=debian
-
-  - services: docker
-    env:
-    - SPARK_VERSION=2.1.0
-    - HADOOP_VERSION=2.7.3
-    - WITH_HIVE=true
-    - WITH_PYSPARK=true
-    - DIST=debian
-
-  - services: docker
-    env:
-    - SPARK_VERSION=2.0.2
-    - HADOOP_VERSION=2.7.3
-    - WITH_HIVE=true
-    - WITH_PYSPARK=false
-    - DIST=debian
-
-  - services: docker
-    env:
-    - SPARK_VERSION=2.0.1
-    - HADOOP_VERSION=2.7.3
-    - WITH_HIVE=true
-    - WITH_PYSPARK=false
-    - DIST=debian
-
-  - services: docker
-    env:
-    - SPARK_VERSION=2.0.0
-    - HADOOP_VERSION=2.7.3
-    - WITH_HIVE=true
-    - WITH_PYSPARK=false
     - DIST=debian
 
   # Alpine builds
 
   - services: docker
     env:
-    - SPARK_VERSION=2.4.2
+    - SPARK_VERSION=2.4.3
     - HADOOP_VERSION=3.1.0
+    - WITH_KUBERNETES=true
     - WITH_HIVE=true
     - WITH_PYSPARK=true
     - DIST=alpine
 
   - services: docker
     env:
-    - SPARK_VERSION=2.4.2
+    - SPARK_VERSION=2.4.3
     - HADOOP_VERSION=2.7.3
+    - WITH_KUBERNETES=true
     - WITH_HIVE=true
     - WITH_PYSPARK=true
     - DIST=alpine
 
   - services: docker
     env:
-    - SPARK_VERSION=2.4.1
+    - SPARK_VERSION=2.4.3
     - HADOOP_VERSION=3.1.0
+    - WITH_KUBERNETES=false
     - WITH_HIVE=true
     - WITH_PYSPARK=true
     - DIST=alpine
 
   - services: docker
     env:
-    - SPARK_VERSION=2.4.1
+    - SPARK_VERSION=2.4.3
     - HADOOP_VERSION=2.7.3
-    - WITH_HIVE=true
-    - WITH_PYSPARK=true
-    - DIST=alpine
-
-  - services: docker
-    env:
-    - SPARK_VERSION=2.4.0
-    - HADOOP_VERSION=3.1.0
-    - WITH_HIVE=true
-    - WITH_PYSPARK=true
-    - DIST=alpine
-
-  - services: docker
-    env:
-    - SPARK_VERSION=2.4.0
-    - HADOOP_VERSION=2.7.3
+    - WITH_KUBERNETES=false
     - WITH_HIVE=true
     - WITH_PYSPARK=true
     - DIST=alpine
@@ -230,30 +122,16 @@ matrix:
     env:
     - SPARK_VERSION=2.3.3
     - HADOOP_VERSION=2.7.3
+    - WITH_KUBERNETES=true
     - WITH_HIVE=true
     - WITH_PYSPARK=true
     - DIST=alpine
 
   - services: docker
     env:
-    - SPARK_VERSION=2.3.2
+    - SPARK_VERSION=2.3.3
     - HADOOP_VERSION=2.7.3
-    - WITH_HIVE=true
-    - WITH_PYSPARK=true
-    - DIST=alpine
-
-  - services: docker
-    env:
-    - SPARK_VERSION=2.3.1
-    - HADOOP_VERSION=2.7.3
-    - WITH_HIVE=true
-    - WITH_PYSPARK=true
-    - DIST=alpine
-
-  - services: docker
-    env:
-    - SPARK_VERSION=2.3.0
-    - HADOOP_VERSION=2.7.3
+    - WITH_KUBERNETES=false
     - WITH_HIVE=true
     - WITH_PYSPARK=true
     - DIST=alpine
@@ -262,30 +140,7 @@ matrix:
     env:
     - SPARK_VERSION=2.2.3
     - HADOOP_VERSION=2.7.3
-    - WITH_HIVE=true
-    - WITH_PYSPARK=true
-    - DIST=alpine
-
-  - services: docker
-    env:
-    - SPARK_VERSION=2.2.2
-    - HADOOP_VERSION=2.7.3
-    - WITH_HIVE=true
-    - WITH_PYSPARK=true
-    - DIST=alpine
-
-  - services: docker
-    env:
-    - SPARK_VERSION=2.2.1
-    - HADOOP_VERSION=2.7.3
-    - WITH_HIVE=true
-    - WITH_PYSPARK=true
-    - DIST=alpine
-
-  - services: docker
-    env:
-    - SPARK_VERSION=2.2.0
-    - HADOOP_VERSION=2.7.3
+    - WITH_KUBERNETES=false
     - WITH_HIVE=true
     - WITH_PYSPARK=true
     - DIST=alpine
@@ -294,68 +149,23 @@ matrix:
     env:
     - SPARK_VERSION=2.1.3
     - HADOOP_VERSION=2.7.3
+    - WITH_KUBERNETES=false
     - WITH_HIVE=true
     - WITH_PYSPARK=true
-    - DIST=alpine
-
-  - services: docker
-    env:
-    - SPARK_VERSION=2.1.2
-    - HADOOP_VERSION=2.7.3
-    - WITH_HIVE=true
-    - WITH_PYSPARK=true
-    - DIST=alpine
-
-  - services: docker
-    env:
-    - SPARK_VERSION=2.1.1
-    - HADOOP_VERSION=2.7.3
-    - WITH_HIVE=true
-    - WITH_PYSPARK=true
-    - DIST=alpine
-
-  - services: docker
-    env:
-    - SPARK_VERSION=2.1.0
-    - HADOOP_VERSION=2.7.3
-    - WITH_HIVE=true
-    - WITH_PYSPARK=true
-    - DIST=alpine
-
-  - services: docker
-    env:
-    - SPARK_VERSION=2.0.2
-    - HADOOP_VERSION=2.7.3
-    - WITH_HIVE=true
-    - WITH_PYSPARK=false
-    - DIST=alpine
-
-  - services: docker
-    env:
-    - SPARK_VERSION=2.0.1
-    - HADOOP_VERSION=2.7.3
-    - WITH_HIVE=true
-    - WITH_PYSPARK=false
-    - DIST=alpine
-
-  - services: docker
-    env:
-    - SPARK_VERSION=2.0.0
-    - HADOOP_VERSION=2.7.3
-    - WITH_HIVE=true
-    - WITH_PYSPARK=false
     - DIST=alpine
 
   
 script:
 - docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}"
+- KUBERNETES_TAG_SUFFIX=$(if [ "${WITH_KUBERNETES}" = "true" ]; then echo _k8s; fi)
 - HIVE_TAG_SUFFIX=$(if [ "${WITH_HIVE}" = "true" ]; then echo _hive; fi)
 - PYSPARK_TAG_SUFFIX=$(if [ "${WITH_PYSPARK}" = "true" ]; then echo _pyspark; fi)
-- TAG_NAME=${SPARK_VERSION}_hadoop-${HADOOP_VERSION}${HIVE_TAG_SUFFIX}${PYSPARK_TAG_SUFFIX}_${DIST}
+- TAG_NAME=${SPARK_VERSION}_hadoop-${HADOOP_VERSION}${KUBERNETES_TAG_SUFFIX}${HIVE_TAG_SUFFIX}${PYSPARK_TAG_SUFFIX}_${DIST}
 - FULL_IMAGE_NAME="${IMAGE_NAME}:${TAG_NAME}"
 - |-
   docker build ${DIST}/ -t ${FULL_IMAGE_NAME} \
     --build-arg SPARK_VERSION=${SPARK_VERSION} \
+    --build-arg WITH_KUBERNETES=${WITH_KUBERNETES} \
     --build-arg HADOOP_VERSION=${HADOOP_VERSION} \
     --build-arg WITH_HIVE=${WITH_HIVE} \
     --build-arg WITH_PYSPARK=${WITH_PYSPARK} \

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,25 @@ matrix:
     env:
     - SPARK_VERSION=2.2.3
     - HADOOP_VERSION=2.7.3
+    - WITH_KUBERNETES=true
+    - WITH_HIVE=true
+    - WITH_PYSPARK=true
+    - DIST=debian
+
+  - services: docker
+    env:
+    - SPARK_VERSION=2.2.3
+    - HADOOP_VERSION=2.7.3
     - WITH_KUBERNETES=false
+    - WITH_HIVE=true
+    - WITH_PYSPARK=true
+    - DIST=debian
+
+  - services: docker
+    env:
+    - SPARK_VERSION=2.1.3
+    - HADOOP_VERSION=2.7.3
+    - WITH_KUBERNETES=true
     - WITH_HIVE=true
     - WITH_PYSPARK=true
     - DIST=debian
@@ -140,7 +158,25 @@ matrix:
     env:
     - SPARK_VERSION=2.2.3
     - HADOOP_VERSION=2.7.3
+    - WITH_KUBERNETES=true
+    - WITH_HIVE=true
+    - WITH_PYSPARK=true
+    - DIST=alpine
+
+  - services: docker
+    env:
+    - SPARK_VERSION=2.2.3
+    - HADOOP_VERSION=2.7.3
     - WITH_KUBERNETES=false
+    - WITH_HIVE=true
+    - WITH_PYSPARK=true
+    - DIST=alpine
+
+  - services: docker
+    env:
+    - SPARK_VERSION=2.1.3
+    - HADOOP_VERSION=2.7.3
+    - WITH_KUBERNETES=true
     - WITH_HIVE=true
     - WITH_PYSPARK=true
     - DIST=alpine

--- a/.travis.yml.tmpl
+++ b/.travis.yml.tmpl
@@ -12,6 +12,7 @@ matrix:
     env:
     - SPARK_VERSION={{ v.spark }}
     - HADOOP_VERSION={{ v.hadoop }}
+    - WITH_KUBERNETES={{ v.with_kubernetes }}
     - WITH_HIVE={{ v.with_hive }}
     - WITH_PYSPARK={{ v.with_pyspark }}
     - DIST=debian
@@ -22,6 +23,7 @@ matrix:
     env:
     - SPARK_VERSION={{ v.spark }}
     - HADOOP_VERSION={{ v.hadoop }}
+    - WITH_KUBERNETES={{ v.with_kubernetes }}
     - WITH_HIVE={{ v.with_hive }}
     - WITH_PYSPARK={{ v.with_pyspark }}
     - DIST=alpine
@@ -29,13 +31,15 @@ matrix:
   
 script:
 - docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}"
+- KUBERNETES_TAG_SUFFIX=$(if [ "${WITH_KUBERNETES}" = "true" ]; then echo _k8s; fi)
 - HIVE_TAG_SUFFIX=$(if [ "${WITH_HIVE}" = "true" ]; then echo _hive; fi)
 - PYSPARK_TAG_SUFFIX=$(if [ "${WITH_PYSPARK}" = "true" ]; then echo _pyspark; fi)
-- TAG_NAME=${SPARK_VERSION}_hadoop-${HADOOP_VERSION}${HIVE_TAG_SUFFIX}${PYSPARK_TAG_SUFFIX}_${DIST}
+- TAG_NAME=${SPARK_VERSION}_hadoop-${HADOOP_VERSION}${KUBERNETES_TAG_SUFFIX}${HIVE_TAG_SUFFIX}${PYSPARK_TAG_SUFFIX}_${DIST}
 - FULL_IMAGE_NAME="${IMAGE_NAME}:${TAG_NAME}"
 - |-
   docker build ${DIST}/ -t ${FULL_IMAGE_NAME} \
     --build-arg SPARK_VERSION=${SPARK_VERSION} \
+    --build-arg WITH_KUBERNETES=${WITH_KUBERNETES} \
     --build-arg HADOOP_VERSION=${HADOOP_VERSION} \
     --build-arg WITH_HIVE=${WITH_HIVE} \
     --build-arg WITH_PYSPARK=${WITH_PYSPARK} \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -19,6 +19,9 @@ ENV SPARK_VERSION ${SPARK_VERSION}
 ARG HADOOP_VERSION
 ENV HADOOP_VERSION ${HADOOP_VERSION}
 
+# Kubernetes is only supported >= Spark 2.3
+ARG WITH_KUBERNETES="false"
+
 # Hive integration with Spark is always at 1.2.1-spark2
 ARG WITH_HIVE="true"
 ARG WITH_PYSPARK="true"
@@ -37,6 +40,8 @@ RUN set -euo pipefail && \
     git clone https://github.com/apache/spark.git -b v${SPARK_VERSION}; \
     cd /spark; \
     # Spark installation
+    ## Kubernetes prep
+    KUBERNETES_INSTALL_FLAG=$(if [ "${WITH_KUBERNETES}" = "true" ]; then echo "-Pkubernetes"; fi); \
     ## Hive prep
     HIVE_INSTALL_FLAG=$(if [ "${WITH_HIVE}" = "true" ]; then echo "-Phive"; fi); \
     ## Pyspark prep
@@ -50,6 +55,7 @@ RUN set -euo pipefail && \
     ./dev/make-distribution.sh \
         ${PYSPARK_INSTALL_FLAG} --name spark-${SPARK_VERSION}_hadoop-${HADOOP_VERSION} \
         -Phadoop-$(echo ${HADOOP_VERSION} | cut -c 1-3) \
+        ${KUBERNETES_INSTALL_FLAG} \
         ${HIVE_INSTALL_FLAG} \
         -Dhadoop.version=${HADOOP_VERSION} \
         -DskipTests \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -20,6 +20,9 @@ ENV SPARK_VERSION ${SPARK_VERSION}
 ARG HADOOP_VERSION
 ENV HADOOP_VERSION ${HADOOP_VERSION}
 
+# Kubernetes is only supported >= Spark 2.3
+ARG WITH_KUBERNETES="false"
+
 # Hive integration with Spark is always at 1.2.1-spark2
 ARG WITH_HIVE="true"
 ARG WITH_PYSPARK="true"
@@ -38,6 +41,8 @@ RUN set -euo pipefail && \
     git clone https://github.com/apache/spark.git -b v${SPARK_VERSION}; \
     cd /spark; \
     # Spark installation
+    ## Kubernetes prep
+    KUBERNETES_INSTALL_FLAG=$(if [ "${WITH_KUBERNETES}" = "true" ]; then echo "-Pkubernetes"; fi); \
     ## Hive prep
     HIVE_INSTALL_FLAG=$(if [ "${WITH_HIVE}" = "true" ]; then echo "-Phive"; fi); \
     ## Pyspark prep
@@ -50,6 +55,7 @@ RUN set -euo pipefail && \
     ./dev/make-distribution.sh \
         ${PYSPARK_INSTALL_FLAG} --name spark-${SPARK_VERSION}_hadoop-${HADOOP_VERSION} \
         -Phadoop-$(echo ${HADOOP_VERSION} | cut -c 1-3) \
+        ${KUBERNETES_INSTALL_FLAG} \
         ${HIVE_INSTALL_FLAG} \
         -Dhadoop.version=${HADOOP_VERSION} \
         -DskipTests \

--- a/vars.yml
+++ b/vars.yml
@@ -1,106 +1,48 @@
 versions:
-- spark:  2.4.2
+- spark:  2.4.3
   hadoop: 3.1.0
+  with_kubernetes: "true"
   with_hive: "true"
   with_pyspark: "true"
 
-- spark:  2.4.2
+- spark:  2.4.3
   hadoop: 2.7.3
+  with_kubernetes: "true"
   with_hive: "true"
   with_pyspark: "true"
 
-- spark:  2.4.1
+- spark:  2.4.3
   hadoop: 3.1.0
+  with_kubernetes: "false"
   with_hive: "true"
   with_pyspark: "true"
 
-- spark:  2.4.1
+- spark:  2.4.3
   hadoop: 2.7.3
-  with_hive: "true"
-  with_pyspark: "true"
-
-- spark:  2.4.0
-  hadoop: 3.1.0
-  with_hive: "true"
-  with_pyspark: "true"
-
-- spark:  2.4.0
-  hadoop: 2.7.3
+  with_kubernetes: "false"
   with_hive: "true"
   with_pyspark: "true"
 
 - spark:  2.3.3
   hadoop: 2.7.3
+  with_kubernetes: "true"
   with_hive: "true"
   with_pyspark: "true"
 
-- spark:  2.3.2
+- spark:  2.3.3
   hadoop: 2.7.3
-  with_hive: "true"
-  with_pyspark: "true"
-
-- spark:  2.3.1
-  hadoop: 2.7.3
-  with_hive: "true"
-  with_pyspark: "true"
-
-- spark:  2.3.0
-  hadoop: 2.7.3
+  with_kubernetes: "false"
   with_hive: "true"
   with_pyspark: "true"
 
 - spark:  2.2.3
   hadoop: 2.7.3
-  with_hive: "true"
-  with_pyspark: "true"
-
-- spark:  2.2.2
-  hadoop: 2.7.3
-  with_hive: "true"
-  with_pyspark: "true"
-
-- spark:  2.2.1
-  hadoop: 2.7.3
-  with_hive: "true"
-  with_pyspark: "true"
-
-- spark:  2.2.0
-  hadoop: 2.7.3
+  with_kubernetes: "false"
   with_hive: "true"
   with_pyspark: "true"
 
 - spark:  2.1.3
   hadoop: 2.7.3
+  with_kubernetes: "false"
   with_hive: "true"
   with_pyspark: "true"
-
-- spark:  2.1.2
-  hadoop: 2.7.3
-  with_hive: "true"
-  with_pyspark: "true"
-
-- spark:  2.1.1
-  hadoop: 2.7.3
-  with_hive: "true"
-  with_pyspark: "true"
-
-- spark:  2.1.0
-  hadoop: 2.7.3
-  with_hive: "true"
-  with_pyspark: "true"
-
-# Spark version 2.0.z does not have pyspark distribution
-- spark:  2.0.2
-  hadoop: 2.7.3
-  with_hive: "true"
-  with_pyspark: "false"
-
-- spark:  2.0.1
-  hadoop: 2.7.3
-  with_hive: "true"
-  with_pyspark: "false"
-
-- spark:  2.0.0
-  hadoop: 2.7.3
-  with_hive: "true"
-  with_pyspark: "false"

--- a/vars.yml
+++ b/vars.yml
@@ -37,7 +37,19 @@ versions:
 
 - spark:  2.2.3
   hadoop: 2.7.3
+  with_kubernetes: "true"
+  with_hive: "true"
+  with_pyspark: "true"
+
+- spark:  2.2.3
+  hadoop: 2.7.3
   with_kubernetes: "false"
+  with_hive: "true"
+  with_pyspark: "true"
+
+- spark:  2.1.3
+  hadoop: 2.7.3
+  with_kubernetes: "true"
   with_hive: "true"
   with_pyspark: "true"
 


### PR DESCRIPTION
Drop Spark 2.0 since it is the odd one out and not have PySpark.